### PR TITLE
Fix a bug that config struct which contains interface occurs panic

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -219,6 +219,10 @@ func convertCustomValue(t reflect.Type, s string) (reflect.Value, error) {
 }
 
 func assignIfSuccessful(rv reflect.Value, cb func(reflect.Value) (bool, error)) (assigned bool, err error) {
+	if rv.Kind() == reflect.Interface {
+		return false, errors.New("interface is not assigned")
+	}
+
 	if rv.Kind() == reflect.Ptr {
 		// We have a pointer. Does the thing point to anything?
 		if rv.Elem().IsValid() {
@@ -305,6 +309,10 @@ func decodeStructValue(ctx context.Context, rv reflect.Value, src Source) (assig
 
 			if !convertCustom(fv.Type()) {
 				sft := sf.Type
+				if sft.Kind() == reflect.Interface {
+					return false, errors.New("interface is not decoded")
+				}
+
 				if sft.Kind() == reflect.Ptr {
 					sft = sft.Elem()
 				}

--- a/env/env.go
+++ b/env/env.go
@@ -219,8 +219,8 @@ func convertCustomValue(t reflect.Type, s string) (reflect.Value, error) {
 }
 
 func assignIfSuccessful(rv reflect.Value, cb func(reflect.Value) (bool, error)) (assigned bool, err error) {
-	if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
-		// We have a pointer (or an interface). Does the thing point to anything?
+	if rv.Kind() == reflect.Ptr {
+		// We have a pointer. Does the thing point to anything?
 		if rv.Elem().IsValid() {
 			// Okay, the pointer does point to something. In this case, the
 			// caller has already explicitly initialized the value, so we
@@ -305,7 +305,7 @@ func decodeStructValue(ctx context.Context, rv reflect.Value, src Source) (assig
 
 			if !convertCustom(fv.Type()) {
 				sft := sf.Type
-				if sft.Kind() == reflect.Ptr || sft.Kind() == reflect.Interface {
+				if sft.Kind() == reflect.Ptr {
 					sft = sft.Elem()
 				}
 

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -25,8 +25,6 @@ func (c *Custom) UnmarshalEnv(s string) error {
 	return nil
 }
 
-type Interface interface{}
-
 type Spec struct {
 	Embedded
 	SimpleString          string
@@ -57,8 +55,8 @@ type Spec struct {
 	CustomUnmarshal       Custom          `split_words:"true"`
 	Map                   map[string]string
 	FOOCapitalized        string `split_words:"true"` // this should become FOO_CAPITALIZED
-	Interface             Interface
-	InterfacePtr          *Interface
+	Interface             interface{}
+	InterfacePtr          *interface{}
 }
 
 type Embedded struct {
@@ -120,7 +118,7 @@ func TestDecode(t *testing.T) {
 	t.Logf("%#v", s)
 
 	ptr := "pointer"
-	var intf Interface
+	var intf interface{}
 	var expected = Spec{
 		Embedded:              Embedded{Message: "Hello, Embedded!"},
 		SimpleString:          "foo",

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -109,6 +109,10 @@ func TestDecode(t *testing.T) {
 	os.Setenv("MYAPP_MAP", "foo=1,bar=2,baz=three")
 	os.Setenv("MYAPP_FOO_CAPITALIZED", "camelcase handled correctly")
 
+	// environment variable for interface isn't used
+	os.Setenv("MYAPP_INTERFACE", "interface")
+	os.Setenv("MYAPP_INTERFACEPTR", "pointer to interface")
+
 	if err := env.NewDecoder(env.System).Prefix("MYAPP").Decode(&s); !assert.NoError(t, err, "Decode should succeed") {
 		t.Logf("%s", err)
 		return
@@ -116,6 +120,7 @@ func TestDecode(t *testing.T) {
 	t.Logf("%#v", s)
 
 	ptr := "pointer"
+	var intf Interface
 	var expected = Spec{
 		Embedded:              Embedded{Message: "Hello, Embedded!"},
 		SimpleString:          "foo",
@@ -145,6 +150,8 @@ func TestDecode(t *testing.T) {
 		CustomUnmarshal:       Custom{v: 39},
 		Map:                   map[string]string{"foo": "1", "bar": "2", "baz": "three"},
 		FOOCapitalized:        "camelcase handled correctly",
+		Interface:             nil,
+		InterfacePtr:          &intf,
 	}
 
 	if !assert.Equal(t, expected, s, "result should match") {

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -25,9 +25,7 @@ func (c *Custom) UnmarshalEnv(s string) error {
 	return nil
 }
 
-type Interface interface {
-	Func(string) error
-}
+type Interface interface{}
 
 type Spec struct {
 	Embedded

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -25,6 +25,10 @@ func (c *Custom) UnmarshalEnv(s string) error {
 	return nil
 }
 
+type Interface interface {
+	Func(string) error
+}
+
 type Spec struct {
 	Embedded
 	SimpleString          string
@@ -55,6 +59,8 @@ type Spec struct {
 	CustomUnmarshal       Custom          `split_words:"true"`
 	Map                   map[string]string
 	FOOCapitalized        string `split_words:"true"` // this should become FOO_CAPITALIZED
+	Interface             Interface
+	InterfacePtr          *Interface
 }
 
 type Embedded struct {


### PR DESCRIPTION
I met panic when [redis.Options of go-redis](https://github.com/go-redis/redis/blob/346c00d485fc72b92d5bd935535ba322df2be5d3/options.go#L16-L70
) is decoded by go-config.

I found the cause. A struct which contains interface occurs panic (It's not a pointer of an interface). In the case of go-redis, redis.Options contains [io.Reader in TLSConfig](https://github.com/go-redis/redis/blob/346c00d485fc72b92d5bd935535ba322df2be5d3/options.go#L69).

Then, I fixed the problem. But, I'm not sure that it's correct way. Please take a look.

[Trace route of the panic]:
```
--- FAIL: TestDecode (0.00s)
panic: reflect: Elem of invalid type [recovered]
	panic: reflect: Elem of invalid type

goroutine 35 [running]:
testing.tRunner.func1(0xc420080dd0)
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:622 +0x29d
panic(0x12e7a60, 0xc420126800)
	/usr/local/Cellar/go/1.8.1/libexec/src/runtime/panic.go:489 +0x2cf
reflect.(*rtype).Elem(0x1308980, 0xc4200d6978, 0x194)
	/usr/local/Cellar/go/1.8.1/libexec/src/reflect/type.go:954 +0xde
github.com/lestrrat/go-config/env.assignIfSuccessful(0x1308980, 0xc4200d6978, 0x194, 0xc42004b660, 0x1308900, 0x0, 0x0)
	/Users/junichi/Projects/gopath/src/github.com/lestrrat/go-config/env/env.go:243 +0x158
github.com/lestrrat/go-config/env.decodeStructValue(0x17140f0, 0xc42007b620, 0x1353e80, 0xc4200d6840, 0x199, 0x14b3060, 0x1369e70, 0x15a1901, 0x0, 0x0)
	/Users/junichi/Projects/gopath/src/github.com/lestrrat/go-config/env/env.go:340 +0x278
github.com/lestrrat/go-config/env.decodeValue.func1(0x1353e80, 0xc4200d6840, 0x199, 0x1353e80, 0xc4200d6840, 0x199)
	/Users/junichi/Projects/gopath/src/github.com/lestrrat/go-config/env/env.go:275 +0x7a
github.com/lestrrat/go-config/env.assignIfSuccessful(0x12d7f20, 0xc4200d6840, 0x16, 0xc42003a828, 0x1310500, 0x0, 0x0)
	/Users/junichi/Projects/gopath/src/github.com/lestrrat/go-config/env/env.go:263 +0xe6
github.com/lestrrat/go-config/env.decodeValue(0x17140f0, 0xc42007b620, 0x12d7f20, 0xc4200d6840, 0x16, 0x14b3060, 0x1369e70, 0xc42007b600, 0x0, 0x0)
	/Users/junichi/Projects/gopath/src/github.com/lestrrat/go-config/env/env.go:279 +0xe9
github.com/lestrrat/go-config/env.(*Decoder).Decode(0xc42003aa28, 0x12d7f20, 0xc4200d6840, 0x0, 0x0)
	/Users/junichi/Projects/gopath/src/github.com/lestrrat/go-config/env/env.go:47 +0x291
github.com/lestrrat/go-config/env_test.TestDecode(0xc420080dd0)
	/Users/junichi/Projects/gopath/src/github.com/lestrrat/go-config/env/env_test.go:114 +0x75f
testing.tRunner(0xc420080dd0, 0x13699d8)
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:697 +0x2ca
FAIL	github.com/lestrrat/go-config/env	0.015s
?   	github.com/lestrrat/go-config/env/internal/structtag	[no test files]
```